### PR TITLE
output template image, fix init preview figsize and events preview size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 	-docker images | grep $(FULL_NAME) | awk '{print $$1 ":" $$2}' | grep -v $(VERSION) | xargs docker rmi
 
 build:
-	@PACKAGE_REQS=$$(if [ -f ../.dev_requirements.txt ]; then cat ../.dev_requirements.txt | grep -v "#" | tr '\n' ' '; else echo "ideas-public-python-utils@git+https://@github.com/inscopix/ideas-public-python-utils.git@0.0.17 caiman@git+https://github.com/inscopix/CaImAn.git@v0.0.6 isx==2.0.0"; fi) && \
+	@PACKAGE_REQS=$$(if [ -f ../.dev_requirements.txt ]; then cat ../.dev_requirements.txt | grep -v "#" | tr '\n' ' '; else echo "ideas-public-python-utils@git+https://@github.com/inscopix/ideas-public-python-utils.git@0.0.17 caiman@git+https://github.com/inscopix/CaImAn.git@v0.0.8 isx==2.0.1"; fi) && \
 	echo "Building docker image with PACKAGE_REQS: $$PACKAGE_REQS" && \
 	DOCKER_BUILDKIT=1 docker build . -t $(IMAGE_TAG) \
 		--platform ${PLATFORM} \

--- a/info/rename_rules_caiman_isx_academic__caiman_workflow.json
+++ b/info/rename_rules_caiman_isx_academic__caiman_workflow.json
@@ -28,6 +28,13 @@
             ],
             "custom_string": "neural_events"
         },
+        "local_corr_img": {
+            "pattern": [
+                "input_movie_files",
+                "custom_string"
+            ],
+            "custom_string": "local_corr_img"
+        },
         "initialization_images": {
             "pattern": [
                 "input_movie_files",
@@ -83,6 +90,10 @@
                 "custom_string"
             ],
             "custom_string": "caiman_output_footprints"
+        },
+        "local_corr_img_preview": {
+            "pattern": [],
+            "custom_string": ""
         }
     }
 }

--- a/info/results_caiman_isx_academic__caiman_workflow.json
+++ b/info/results_caiman_isx_academic__caiman_workflow.json
@@ -68,6 +68,23 @@
         "preview_of": []
     },
     {
+        "key": "local_corr_img",
+        "analysis_table_result_column_name": "Template Image",
+        "file_type": "image",
+        "file_format": "tif",
+        "file_structure": "image",
+        "file_category": "result",
+        "help": "Local correlation image in TIF format",
+        "required": false,
+        "multiple": false,
+        "is_preview": false,
+        "is_output": true,
+        "parent_keys": [
+            "input_movie_files"
+        ],
+        "preview_of": []
+    },
+    {
         "key": "initialization_images",
         "analysis_table_result_column_name": "Initialization Images",
         "file_type": "",
@@ -217,6 +234,25 @@
         ],
         "preview_of": [
             "caiman_output"
+        ]
+    },
+    {
+        "key": "local_corr_img_preview",
+        "analysis_table_result_column_name": "Preview Template Image",
+        "file_type": "image",
+        "file_format": "png",
+        "file_structure": "image",
+        "file_category": "result",
+        "help": "Local correlation image (from local_corr_img.tif)",
+        "required": false,
+        "multiple": false,
+        "is_preview": true,
+        "is_output": false,
+        "parent_keys": [
+            "input_movie_files"
+        ],
+        "preview_of": [
+            "local_corr_img"
         ]
     }
 ]

--- a/info/toolbox_info.json
+++ b/info/toolbox_info.json
@@ -23,7 +23,7 @@
             "name": "CaImAn Cell Extraction Workflow",
             "key": "caiman_isx_academic__caiman_workflow",
             "help": "The CaImAn cell identification workflow performs motion correction using the NoRMCorre algorithm, cell identification using the CNMF/CNMF-E algorithm, and automated component evaluation.",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "maturity": "production",
             "visibility": "public",
             "toolkit": "Calcium Imaging Processing",
@@ -128,6 +128,23 @@
                         }
                     },
                     "default": false
+                },
+                {
+                    "key": "save_img",
+                    "name": "Save Template Image",
+                    "required": false,
+                    "hidden": false,
+                    "help": "Whether to save the local correlation image as a standalone .tif file, e.g., for further use as template image in Multi-Session Registration.",
+                    "type": {
+                        "is_source": false,
+                        "param_type": "ToolBooleanParam",
+                        "param_datatype": "boolean",
+                        "display": {
+                            "group": "Settings",
+                            "group_order": 1
+                        }
+                    },
+                    "default": true
                 },
                 {
                     "key": "fr",
@@ -1036,6 +1053,17 @@
                                 "isxd"
                             ],
                             "file_type": "neural_events"
+                        },
+                        {
+                            "result_key": "local_corr_img",
+                            "result_name": "Template Image",
+                            "help": "Local correlation image in TIF format",
+                            "required": false,
+                            "multiple": false,
+                            "file_formats": [
+                                "tif"
+                            ],
+                            "file_type": "image"
                         }
                     ]
                 }

--- a/toolbox/tools/caiman_isx_academic.py
+++ b/toolbox/tools/caiman_isx_academic.py
@@ -21,11 +21,13 @@ from toolbox.utils.utilities import get_file_size
 from toolbox.utils.data_conversion import (
     convert_caiman_output_to_isxd,
     convert_memmap_data_to_output_files,
+    save_local_correlation_image,
 )
 from toolbox.utils.qc import generate_motion_correction_quality_assessment_data
 from toolbox.utils.previews import (
     generate_caiman_motion_corrected_previews,
     generate_initialization_images_preview,
+    generate_local_correlation_image_preview,
 )
 from toolbox.utils.metadata import generate_caiman_motion_correction_metadata
 
@@ -39,7 +41,9 @@ def caiman_workflow(
     # Input Files
     input_movie_files: List[str],
     parameters_file: Optional[List[str]] = None,
+    # Settings
     overwrite_analysis_table_params: bool = False,
+    save_img: bool = True,
     # Dataset
     fr: str = "auto",
     decay_time: float = 0.4,
@@ -107,6 +111,7 @@ def caiman_workflow(
     SETTINGS
     :param overwrite_analysis_table_params: if True and a parameters file is provided, the analysis table columns
                                             will be overwritten by the values specified in the parameters file
+    :param save_img: if True, local correlation image will be saved as a standalone .tif file
 
     DATASET
     :param fr: imaging rate in frames per second (If set to 'auto', the frame rate will be set based on file metadata if available. Otherwise, it will use CaImAn's default frame rate of 30)
@@ -443,6 +448,17 @@ def caiman_workflow(
         f"({os.path.basename(caiman_output_filename)}, "
         f"size: {get_file_size(caiman_output_filename)})"
     )
+
+    # (optional) save local correlation image
+    if save_img:
+        image_output_filename = os.path.join(output_dir, "local_corr_img.tif")
+        save_local_correlation_image(
+            correlation_image=correlation_image,
+            image_output_filename=image_output_filename,
+        )
+        generate_local_correlation_image_preview(
+            correlation_image=correlation_image,
+        )
 
     # ensure some cells were identified
     num_cells = len(model.estimates.C)

--- a/toolbox/utils/data_conversion.py
+++ b/toolbox/utils/data_conversion.py
@@ -409,3 +409,22 @@ def convert_memmap_data_to_output_files(
         )
 
     return mc_movie_filenames, num_frames_per_movie, frame_index_cutoffs
+
+
+def save_local_correlation_image(
+    correlation_image,
+    image_output_filename,
+):
+    """
+    Save the local correlation image as a standalone .tif file, e.g.,
+    for further use as template image in Multi-Session Registration.
+
+    :param correlation_image: local correlation image computed during CNMF-E initialization
+    :param image_output_filename: path to the output .tif file to be written
+    """
+    tifffile.tifffile.imwrite(image_output_filename, correlation_image)
+    logger.info(
+        "Local correlation image saved"
+        f"({os.path.basename(image_output_filename)}, )"
+        f"size: {get_file_size(image_output_filename)})"
+    )

--- a/toolbox/utils/plots.py
+++ b/toolbox/utils/plots.py
@@ -634,10 +634,15 @@ def save_neural_traces_preview(
         for x in vertical_line_indices:
             plt.axvline(x=time[x], color="gray", ls="--", lw=1, alpha=0.3)
 
-    plt.tight_layout()
+    fig.tight_layout()
 
     logger.info("Saving traces figure...")
-    fig.savefig(output_preview_filename, dpi=300)
+    fig.savefig(
+        output_preview_filename,
+        bbox_inches="tight",
+        pad_inches=0.1,
+        dpi=300,
+    )
 
     logger.info(
         f"Traces preview saved ({os.path.basename(output_preview_filename)}, size: {get_file_size(output_preview_filename)})"
@@ -736,9 +741,11 @@ def save_footprints_preview(
     # invert y-axis to match orientation in IDPS (y=0 at top of image and y=max at bottom)
     ax.invert_yaxis()
 
-    plt.tight_layout()
+    fig.tight_layout()
     fig.savefig(
         output_preview_filename,
+        bbox_inches="tight",
+        pad_inches=0.1,
         dpi=300,
     )
 
@@ -921,7 +928,7 @@ class EventSetPreview(object):
 
         return mean_inter_event_interval[~np.isnan(mean_inter_event_interval)]
 
-    def generate_preview(self):
+    def generate_preview(self, dpi=300):
         """Plot and save event set preview. Preview generates 4 subplots
         1. Raster
         2. A time series of mean event rate across neurons
@@ -1066,4 +1073,4 @@ class EventSetPreview(object):
                     axis.spines["left"].set_color(self.foreground_color)
 
             # Saving the preview
-            plt.savefig(self.output_png_filepath, dpi=300)
+            fig.savefig(self.output_png_filepath, dpi=dpi)

--- a/toolbox/utils/previews.py
+++ b/toolbox/utils/previews.py
@@ -100,6 +100,19 @@ def generate_event_set_preview(eventset_filename: str, output_dir: str = None):
         output_png_filepath=output_events_preview_filepath,
     )
     eventset_preview_obj.generate_preview()
+
+    # if preview file weighs more than 2MB, output again with a lower dpi
+    dpi = 300
+    to_MB = 1 / (1024**2)
+    while abs(os.path.getsize(output_events_preview_filepath)) * to_MB > 2:
+        dpi *= 0.8
+        f_size = abs(os.path.getsize(output_events_preview_filepath)) * to_MB
+        logger.info(
+            f"Neural events preview file was too big ({round(f_size, 2)}"
+            f" > 2MB). Outputting again with dpi={round(dpi, 0)}."
+        )
+        eventset_preview_obj.generate_preview(dpi=dpi)
+
     logger.info(
         f"Neural events preview saved "
         f"({os.path.basename(output_events_preview_filepath)}, "
@@ -809,7 +822,7 @@ def generate_initialization_images_preview(
         )
         search_image = correlation_image * pnr_image
 
-        fig, ax = plt.subplots(nrows=1, ncols=3)
+        fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(12, 4))
 
         # PNR image
         pnr_plot_img = ax[0].imshow(pnr_image)
@@ -834,8 +847,8 @@ def generate_initialization_images_preview(
         ):
             add_colorbar(target_axis=ax[i], img=im)
 
-        plt.tight_layout()
-        plt.savefig(
+        fig.tight_layout()
+        fig.savefig(
             os.path.join(output_dir, "initialization_images.png"),
             bbox_inches="tight",
             dpi=300,
@@ -847,3 +860,32 @@ def generate_initialization_images_preview(
         correlation_image = None
 
     return correlation_image
+
+
+def generate_local_correlation_image_preview(
+    correlation_image,
+    output_dir: str = None,
+):
+    """Generate preview for the local correlation image.
+
+    :param correlation_image: local correlation image computed during CNMF-E initialization
+    :param output_dir: path to the output directory
+    """
+    if output_dir is None:
+        output_dir = os.getcwd()
+
+    try:
+        logger.info("Generating correlation image preview")
+
+        fig, ax = plt.subplots(1, 1, figsize=(6, 6))
+        ax.imshow(correlation_image, cmap="gray")
+        ax.axis("off")
+        fig.tight_layout()
+        plt.savefig(
+            "local_corr_img_preview.png", bbox_inches="tight", pad_inches=0.1
+        )
+
+    except Exception as e:
+        logger.warning(
+            f"Correlation image preview could not be generated: {str(e)}"
+        )

--- a/user_deps.txt
+++ b/user_deps.txt
@@ -22,3 +22,4 @@ bokeh==3.4.2
 holoviews==1.19.1
 imageio==2.35.0
 imageio-ffmpeg==0.4.7
+hdmf==3.14.6


### PR DESCRIPTION
## Description 
This PR encompasses 1 new feature and 2 bug fixes:
- [new feature] output the local correlation image as a standalone .tif file (by default, but can be turned off with an Analysis table parameter), to make `CaImAn Cell Extraction Workflow` compatible with `CaImAn Multi-Session Registration`
- [bug fix 1] [IT-1525](https://inscopix.atlassian.net/browse/IT-1525)
- [bug fix 2] [IT-1535](https://inscopix.atlassian.net/browse/IT-1535)

Also updated packages (CaImAn fork and isx) and fixed a few minor things here and there (e.g., removed unnecessary white padding around footprint preview images).

## Testing 
### Automated Testing
- `make test` running.. will update once it completes

### Manual Testing 
- `make run TOOL=caiman_isx_academic__caiman_workflow` properly created `local_corr_img.tif` and `local_corr_img_preview.png` in `outputs/caiman_isx_academic__caiman_workflow`


[IT-1525]: https://inscopix.atlassian.net/browse/IT-1525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IT-1535]: https://inscopix.atlassian.net/browse/IT-1535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ